### PR TITLE
Fix stock by warehouse for BoostMyShop

### DIFF
--- a/src/Integrate/Warehouse/BootMyShop0015.php
+++ b/src/Integrate/Warehouse/BootMyShop0015.php
@@ -175,8 +175,9 @@ class BootMyShop0015 extends AbstractWarehouseIntegrate implements WarehouseInte
 
         $warehouseStockItem = $item->getData('available_quantity');
 
-        if ($warehouseStockItem) {
+        if ($warehouseStockItem !== null) {
             $defaultStock['qty'] = $warehouseStockItem;
+            $defaultStock['is_in_stock'] =  ($defaultStock['qty'] > 0) ? '1': '0';
         }
 
         return $defaultStock;


### PR DESCRIPTION
There is a bug that products are shown as instock (products grid on sellers screen), but at the same moment, if we check stock for selected warehouse - they are out of stock.
It is not proper compare "if ($warehouseStockItem) {" because if $warehouseStockItem is equal to 0 (so this product is out of stock for this warehouse, it won't override default stock value). 
